### PR TITLE
Improve retrieval evaluation and hybrid search

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ tabulate==0.9.0
 typer==0.12.3            # CLI
 PyYAML==6.0.2
 pytest==8.3.2
+rank-bm25==0.2.2

--- a/src/cli/eval_retrieval_public.py
+++ b/src/cli/eval_retrieval_public.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Dict, Any, List, Tuple, Optional
 import json
+import re
 import pandas as pd
 import typer
 
@@ -21,30 +22,37 @@ def _load_app_cfg() -> dict:
         return yaml.safe_load(f) or {}
 
 
+def _light_answer_norm(s: str) -> str:
+    if s is None:
+        return ""
+    s = str(s)
+    s = s.replace("«", '"').replace("»", '"')
+    s = s.replace("\u00A0", " ")
+    s = re.sub(r"\s+", " ", s)
+    return s.strip()
+
+
 def _load_public_qa(app_cfg: dict) -> List[Dict[str, Any]]:
     """Склеиваем вопросы (xlsx) и ответы (json) в единый список dict-ов."""
     a_path = Path(app_cfg["paths"]["public_answers"])
     q_path = Path(app_cfg["paths"]["public_questions"])
 
-    with open(a_path, "r", encoding="utf-8") as f:
+    with open(a_path, "r", encoding="utf-8-sig") as f:
         answers = json.load(f)
 
     dfa = pd.DataFrame(answers)
-    # ответ может быть разного типа -> приведём к строке для matcher-а, а оригинал сохраним
     dfa["answer_raw"] = dfa["answer"]
-    dfa["answer"] = dfa["answer"].astype(str)
+    dfa["answer"] = dfa["answer"].map(_light_answer_norm)
 
     dfq = pd.read_excel(q_path)
 
-    # Автоопределение колонки с текстом вопроса
     q_col = None
-    for cand in ["question", "query", "full_question", "text", "q"]:
+    for cand in ["question", "query", "full_question"]:
         if cand in dfq.columns:
             q_col = cand
             break
     if not q_col:
-        raise ValueError("В файле вопросов нет подходящей колонки с текстом вопроса "
-                         "(ожидались: question | query | full_question | text | q)")
+        raise ValueError("В файле вопросов нет подходящей колонки с текстом вопроса (question | query | full_question)")
     typer.echo(f"ℹ️ Колонка с вопросом: '{q_col}'")
 
     # Оставим минимум нужного
@@ -73,11 +81,17 @@ def _search_candidates(
     k: int,
     reranker: Optional[Reranker],
     rerank_topn: int,
+    hybrid: bool = False,
 ) -> List[Dict[str, Any]]:
     """Достаём кандидатов и (опц.) переранжируем."""
-    # если есть reranker — нужно оверфетчить достаточно кандидатов
-    fetch_k = max(k, min(max(k * 5, k), rerank_topn) if reranker else k)
-    hits = retr.search(query, k=fetch_k, overfetch=fetch_k if reranker else None)
+    if reranker:
+        fetch_k = max(rerank_topn, 5 * k)
+    else:
+        fetch_k = k
+    if hybrid:
+        hits = retr.search_hybrid(query, k=fetch_k)
+    else:
+        hits = retr.search(query, k=fetch_k, overfetch=fetch_k if reranker else None)
     if reranker:
         hits = reranker.rerank(query, hits, top_k=k)
     else:
@@ -94,6 +108,7 @@ def main(
     rerank_model: Optional[str] = typer.Option(None, "--rerank-model"),
     rerank_topn: int = typer.Option(50, "--rerank-topn", help="сколько кандидатов переранжировать"),
     dump_topk: Optional[str] = typer.Option(None, "--dump-topk", help="путь к CSV с топ-K результатами"),
+    hybrid: bool = typer.Option(False, "--hybrid", help="гибридный BM25+dense поиск"),
 ):
     # 1) данные
     app_cfg = _load_app_cfg()
@@ -115,7 +130,7 @@ def main(
         answer_str = str(item["answer"])  # для релакс-паттернов
         answer_raw = item.get("answer_raw")
 
-        hits = _search_candidates(retr, query, k, rr, rerank_topn)
+        hits = _search_candidates(retr, query, k, rr, rerank_topn, hybrid=hybrid)
 
         # подготовка паттернов на каждый вопрос (один раз)
         pat_list = relaxed_answer_match.compile_patterns(answer_str)
@@ -146,13 +161,21 @@ def main(
                 top10 += 1
                 mrr10_sum += 1.0 / rank_found
 
+        hit_score = ""
+        doc_name = ""
+        page_number = ""
+        if rank_found is not None:
+            hit = hits[rank_found - 1]
+            doc_name = hit.get("doc_name", "")
+            page_number = hit.get("page_number", "")
+            hit_score = hit.get("rerank_score", hit.get("score", ""))
         details_rows.append({
             "qid": qid,
             "top_hit_rank": "MISS" if rank_found is None else rank_found,
-            "doc_name": "" if rank_found is None else hits[rank_found-1]["doc_name"],
-            "page_number": "" if rank_found is None else hits[rank_found-1]["page_number"],
+            "doc_name": doc_name,
+            "page_number": page_number,
             "matched_pattern": matched_pat,
-            "score": hits[0]["rerank_score"] if (hits and "rerank_score" in hits[0]) else (hits[0]["score"] if hits else 0.0),
+            "score": hit_score,
         })
 
         # дампим весь топ-K по каждому вопросу, если попросили
@@ -162,12 +185,14 @@ def main(
                     "question_id": qid,
                     "question": query,
                     "answer_raw": answer_raw,
+                    "answer_type": type(answer_raw).__name__ if answer_raw is not None else "",
                     "rank": rank,
-                    "doc_name": h["doc_name"],
-                    "page_number": h["page_number"],
                     "score": h.get("score"),
                     "rerank_score": h.get("rerank_score"),
+                    "doc_name": h["doc_name"],
+                    "page_number": h["page_number"],
                     "preview": h.get("preview", ""),
+                    "matched_pattern": matched_pat if rank_found == rank else "",
                 })
 
     n = max(len(qa), 1)

--- a/src/retrieval/search.py
+++ b/src/retrieval/search.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 import json
+import re
 import numpy as np
 import pandas as pd
+from rank_bm25 import BM25Okapi
 
 from .embed import EmbeddingModel
 
@@ -26,15 +28,16 @@ class Retriever:
         if self.embeddings.ndim != 2:
             raise ValueError("embeddings.npy должен быть матрицей (N, D)")
 
+        self._bm25: Optional[BM25Okapi] = None
+        self._bm25_corpus: Optional[List[List[str]]] = None
+
     @classmethod
     def from_dir(cls, index_dir: Path, device: Optional[str] = None) -> "Retriever":
         return cls(index_dir, device=device)
 
     def search(self, query: str, k: int = 5, overfetch: Optional[int] = None) -> List[Dict[str, Any]]:
-        # embed запроса c e5-префиксом
-        qv = self.emb.encode([query], is_query=True)[0]  # (D,)
-        # cos sim = dot т.к. векторы уже нормированы
-        sims = self.embeddings @ qv  # (N,)
+        qv = self.emb.encode([query], is_query=True)[0]
+        sims = self.embeddings @ qv
 
         topn = int(min(overfetch or k, sims.shape[0]))
         idxs = np.argpartition(-sims, topn - 1)[:topn]
@@ -55,3 +58,61 @@ class Retriever:
                 }
             )
         return hits[:topn]
+
+    # --- BM25 -----------------------------------------------------------------
+
+    def _ensure_bm25(self) -> None:
+        if self._bm25 is not None:
+            return
+        texts = self.df["text"].astype(str).tolist()
+        tok_corpus = [re.findall(r"\w+", t.lower(), flags=re.UNICODE) for t in texts]
+        self._bm25_corpus = tok_corpus
+        self._bm25 = BM25Okapi(tok_corpus)
+
+    def _bm25_search(self, query: str, k: int) -> List[Dict[str, Any]]:
+        self._ensure_bm25()
+        assert self._bm25 is not None
+        tokens = re.findall(r"\w+", query.lower(), flags=re.UNICODE)
+        scores = self._bm25.get_scores(tokens)
+        topn = int(min(k, len(scores)))
+        idxs = np.argpartition(-scores, topn - 1)[:topn]
+        idxs = idxs[np.argsort(-scores[idxs])]
+        hits: List[Dict[str, Any]] = []
+        for i in idxs:
+            row = self.df.iloc[int(i)]
+            preview = str(row.get("text", ""))[:200]
+            hits.append(
+                {
+                    "score": float(scores[int(i)]),
+                    "doc_name": str(row.get("doc_name", "")),
+                    "page_number": int(row.get("page_number", -1)),
+                    "kind": str(row.get("kind", "page")),
+                    "preview": preview,
+                    "row_index": int(i),
+                }
+            )
+        return hits
+
+    def search_hybrid(self, query: str, k: int = 5, rrf_k: int = 60) -> List[Dict[str, Any]]:
+        dense_hits = self.search(query, k=k)
+        bm25_hits = self._bm25_search(query, k)
+
+        scores: Dict[int, float] = {}
+        merged: Dict[int, Dict[str, Any]] = {}
+        for rank, h in enumerate(dense_hits, start=1):
+            key = h["row_index"]
+            merged[key] = h
+            scores[key] = scores.get(key, 0.0) + 1.0 / (rrf_k + rank)
+        for rank, h in enumerate(bm25_hits, start=1):
+            key = h["row_index"]
+            if key not in merged:
+                merged[key] = h
+            scores[key] = scores.get(key, 0.0) + 1.0 / (rrf_k + rank)
+
+        keys_sorted = sorted(scores.keys(), key=lambda x: scores[x], reverse=True)[:k]
+        hits: List[Dict[str, Any]] = []
+        for key in keys_sorted:
+            h = merged[key].copy()
+            h["score"] = float(scores[key])
+            hits.append(h)
+        return hits

--- a/src/validate/match_utils.py
+++ b/src/validate/match_utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import re
 import unicodedata
 from dataclasses import dataclass
-from typing import Any, List, Tuple
+from typing import Any, List, Tuple, Iterable
 
 
 # --- Нормализация текста -----------------------------------------------------
@@ -41,24 +41,53 @@ def _norm(s: str) -> str:
     return s.strip()
 
 
+def _mojibake_variants(s: str) -> List[str]:
+    """Возвращает список возможных «кракозябренных» вариантов строки.
+
+    Эвристика: пробуем перекодировать latin1/cp1252/cp1251 ↔ utf-8 и
+    оставляем наиболее кириллические версии. Это помогает матчить тексты,
+    где исходная строка была испорчена неверной декодировкой.
+    """
+
+    variants: set[str] = set()
+    enc_pairs: Iterable[tuple[str, str]] = [
+        ("latin1", "utf-8"),
+        ("cp1252", "utf-8"),
+        ("cp1251", "utf-8"),
+        ("utf-8", "latin1"),
+        ("utf-8", "cp1252"),
+        ("utf-8", "cp1251"),
+    ]
+    for src_enc, dst_enc in enc_pairs:
+        try:
+            v = s.encode(src_enc, errors="ignore").decode(dst_enc, errors="ignore")
+            variants.add(v)
+        except Exception:
+            pass
+
+    variants.discard(s)
+
+    def cyr_score(text: str) -> int:
+        return len(re.findall(r"[А-Яа-яЁё]", text))
+
+    # сортируем по количеству кириллицы, оставляем наиболее правдоподобные
+    return sorted(variants, key=cyr_score, reverse=True)[:3]
+
 # --- Построение паттернов ----------------------------------------------------
 
 
-def _tokens_pattern(answer: str) -> str:
+_GAP = r"[ \t\r\n\.,;:!?\-–—\"'()]{0,3}"
+
+
+def _tokens_pattern(answer: str, gap: str = _GAP) -> str:
     """
-    «Склеивающий» паттерн по токенам: разрешаем любые не-алфавитно-цифровые
-    символы между токенами. Это ловит варианты вроде `L.A.C. Holding`,
-    `L A C Holding`, кавычки/скобки/дефисы между словами и т.п.
+    Паттерн по токенам с небольшим допуском на знаки/пробелы между ними.
+    Используем как основу для текстовых ответов.
     """
-    # целые/десятичные числа выделим отдельно в compile_patterns()
-    # здесь нам нужны слова/буквы/цифры как токены
     toks = re.findall(r"\w+|\d+[.,]\d+|\d+", answer, flags=re.UNICODE)
     if not toks:
         return re.escape(answer)
-
-    # \W* между токенами: любые не-словарные символы (точки, пробелы, кавычки...)
-    # границы слова по краям помогают избегать «прилипаний» к соседним словам
-    return r"\b" + r"\W*".join(map(re.escape, toks)) + r"\b"
+    return r"\b" + gap.join(map(re.escape, toks)) + r"\b"
 
 
 @dataclass
@@ -83,42 +112,54 @@ class RelaxedAnswerMatch:
         as_str = str(answer).strip()
         as_str_norm = _norm(as_str)
 
-        # чисто цифры (целое), допускаем, что внутри могли быть пробелы как разделители тысяч
+        # чисто цифры (целое), допускаем разделители тысяч
         only_digits = re.fullmatch(r"\d+(?:\s+\d+)*", as_str_norm)
-        # десятичное с точкой/запятой (возможны пробелы вокруг разделителя)
-        decimal_match = re.fullmatch(r"\d+(?:\s*[.,]\s*\d+)", as_str_norm)
+        # десятичное число с точкой или запятой и опциональными разделителями тысяч
+        decimal_match = re.fullmatch(
+            r"\d+(?:\s+\d+)*(?:\s*[.,]\s*\d+)", as_str_norm
+        )
 
         if only_digits:
-            digits = re.sub(r"\s+", "", as_str_norm)  # убираем разделители тысяч
-            # 1) точное число (без прилегающих цифр)
+            digits = re.sub(r"\s+", "", as_str_norm)
             p1 = rf"(?<!\d){re.escape(digits)}(?!\d)"
-            # 2) тот же набор цифр, но с допуском пробелов/NBSP/узкого пробела между ЛЮБЫМИ цифрами
-            spaced = r"".join([re.escape(d) + r"[\s\u00A0\u2009]*" for d in digits])
+            spaced = r"".join(
+                [re.escape(d) + r"[\s\u00A0\u2009]*" for d in digits]
+            )
             p2 = rf"(?<!\d){spaced}(?!\d)"
             return [p1, p2]
 
         if decimal_match:
-            # приводим к точке как «каноническому» варианту
             canon = re.sub(r"\s*", "", as_str_norm.replace(",", "."))
             head, tail = canon.split(".", 1)
-            # допускаем пробелы вокруг разделителя и сам разделитель , или .
-            p = rf"(?<!\d){re.escape(head)}[\s\u00A0\u2009]*[.,][\s\u00A0\u2009]*{re.escape(tail)}(?!\d)"
-            return [p]
+            p1 = (
+                rf"(?<!\d){re.escape(head)}[\s\u00A0\u2009]*[.,][\s\u00A0\u2009]*{re.escape(tail)}(?!\d)"
+            )
+            spaced_head = "".join(
+                [re.escape(d) + r"[\s\u00A0\u2009]*" for d in head]
+            )
+            spaced_tail = "".join(
+                [re.escape(d) + r"[\s\u00A0\u2009]*" for d in tail]
+            )
+            p2 = (
+                rf"(?<!\d){spaced_head}[\s\u00A0\u2009]*[.,][\s\u00A0\u2009]*{spaced_tail}(?!\d)"
+            )
+            return [p1, p2]
 
         # --- ТЕКСТ -----------------------------------------------------------
         s = _norm(as_str)
         if not s:
             return []
 
-        # основной «склеивающий» паттерн по токенам
-        p_main = _tokens_pattern(s)
+        variants = [s] + _mojibake_variants(s)
+        patterns: List[str] = []
+        for v in variants:
+            v_norm = _norm(v)
+            patterns.append(_tokens_pattern(v_norm, gap=_GAP))
+            patterns.append(_tokens_pattern(v_norm, gap=r"\W*"))
 
-        # запасной вариант: чуть строже, только ограниченный набор знаков между словами
-        toks = [re.escape(t) for t in re.split(r"\s+", s)]
-        gap_lite = r"[ \t\r\n\.,;:!?\-–—\"'()]{0,3}"
-        p_lite = gap_lite.join(toks)
-
-        return [p_main, p_lite]
+        # удалим дубли, сохраняя порядок
+        seen = {}
+        return [seen.setdefault(p, p) for p in patterns if p not in seen]
 
     def any_match(self, text: str, patterns: List[str]) -> Tuple[bool, str]:
         """


### PR DESCRIPTION
## Summary
- robustly load public QA data with BOM-safe JSON, automatic question column detection, and light answer normalization
- add hybrid BM25+dense search with reciprocal-rank fusion and expose `--hybrid` flag
- enhance relaxed answer matching to handle spaced digits, decimals, and mojibake variants
- enrich evaluation outputs with answer metadata and matched patterns

## Testing
- `PYTHONPATH=. pytest`
- `PYTHONPATH=. python -m src.cli.eval_retrieval_public --index data/index_e5 --cache data/cache --k 1 --device cpu --rerank-topn 5 --dump-topk reports/retrieval_topk.csv` *(fails: ModuleNotFoundError: No module named 'sentence_transformers')*

------
https://chatgpt.com/codex/tasks/task_e_68a487ee87508324a4ad882c9d6d8bb7