### PR TITLE
feat: add regex-based answer extraction CLI

### DIFF
--- a/src/cli/answer_public.py
+++ b/src/cli/answer_public.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+from pathlib import Path
+from typing import List, Dict, Any, Optional
+import json
+import pandas as pd
+import typer
+
+from src.retrieval.search import Retriever
+from src.retrieval.rerank import Reranker
+from src.reader.extract import extract_answer_from_hits
+from src.validate.linkcheck import linkcheck
+
+app = typer.Typer(add_completion=False)
+
+
+def _pick_q_col(df: pd.DataFrame) -> str:
+    for c in ["question", "full_question", "query"]:
+        if c in df.columns:
+            return c
+    raise ValueError("Не найдена колонка с текстом вопроса (question|full_question|query)")
+
+
+def _ensure_qid(df: pd.DataFrame) -> pd.DataFrame:
+    if "question_id" in df.columns:
+        return df[["question_id"] + [c for c in df.columns if c != "question_id"]]
+    if "id" in df.columns:
+        df = df.rename(columns={"id": "question_id"})
+        return df
+    raise ValueError("Нет колонки question_id (или id)")
+
+
+@app.command()
+def main(
+    index: str = typer.Option("data/index_e5", "--index"),
+    questions_xlsx: str = typer.Option("data/public/questions_public.xlsx", "--questions"),
+    out_submission: str = typer.Option("submission/submission.json", "--out"),
+    out_md: str = typer.Option("predictions_public.md", "--out-md"),
+    k: int = typer.Option(10, "--k"),
+    device: Optional[str] = typer.Option(None, "--device"),
+    rerank_model: Optional[str] = typer.Option("jinaai/jina-reranker-v2-base-multilingual", "--rerank-model"),
+    rerank_topn: int = typer.Option(300, "--rerank-topn"),
+    hybrid: bool = typer.Option(True, "--hybrid"),
+):
+    Path(out_submission).parent.mkdir(parents=True, exist_ok=True)
+
+    dfq = pd.read_excel(questions_xlsx)
+    dfq = _ensure_qid(dfq)
+    qcol = _pick_q_col(dfq)
+    dfq = dfq[["question_id", qcol]].rename(columns={qcol: "question"})
+
+    retr = Retriever.from_dir(Path(index), device=device)
+    rr = Reranker(rerank_model, device=device) if rerank_model else None
+
+    preds_rows = []
+    sub_out: List[Dict[str, Any]] = []
+
+    for row in dfq.to_dict(orient="records"):
+        qid = int(row["question_id"])
+        q = str(row["question"])
+
+        overfetch = max(k * 5, rerank_topn)
+        hits = (
+            retr.search_hybrid(q, k=overfetch, overfetch=overfetch)
+            if hybrid
+            else retr.search(q, k=overfetch, overfetch=overfetch)
+        )
+        if rr:
+            hits = rr.rerank(q, hits, top_k=overfetch)
+        hits = hits[:k]
+
+        ans = extract_answer_from_hits(q, hits, topk=min(3, len(hits)))
+        best_idx = linkcheck(ans.value, ans.atype, hits, topk=min(3, len(hits)))
+
+        rel: List[Dict[str, Any]] = []
+        if best_idx >= 0:
+            h = hits[best_idx]
+            rel.append(
+                {
+                    "document_name": h.get("doc_name", ""),
+                    "page_number": int(h.get("page_number", -1) or -1),
+                }
+            )
+        else:
+            if hits:
+                h = hits[0]
+                rel.append(
+                    {
+                        "document_name": h.get("doc_name", ""),
+                        "page_number": int(h.get("page_number", -1) or -1),
+                    }
+                )
+
+        preds_rows.append(
+            {
+                "qid": qid,
+                "question": q,
+                "prediction": ans.value,
+                "source": f"{rel[0]['document_name']}:{rel[0]['page_number']}" if rel else "",
+                "link_ok": "✅" if best_idx >= 0 and ans.value != "N/A" else "❌",
+            }
+        )
+
+        sub_out.append(
+            {
+                "question_id": qid,
+                "relevant_chunks": rel if rel else [],
+                "answer": ans.value,
+            }
+        )
+
+    lines = [
+        "# Public QA — predictions",
+        "",
+        "| qid | вопрос | предсказание | источник | link |",
+        "|---:|---|---|---|:---:|",
+    ]
+    for r in preds_rows:
+        lines.append(
+            f"| {r['qid']} | {r['question']} | {r['prediction']} | {r['source']} | {r['link_ok']} |"
+        )
+    Path(out_md).write_text("\n".join(lines), encoding="utf-8")
+
+    Path(out_submission).write_text(
+        json.dumps(sub_out, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    typer.echo(f"Saved: {out_md} and {out_submission}")
+
+
+if __name__ == "__main__":
+    app()

--- a/src/reader/extract.py
+++ b/src/reader/extract.py
@@ -1,0 +1,109 @@
+from dataclasses import dataclass
+from typing import Any, List, Dict, Optional, Tuple
+import re
+
+
+@dataclass
+class Answer:
+    value: Any
+    atype: str
+    matched_hit_idx: Optional[int]  # индекс в списке hits, где найдено
+    matched_span: Optional[Tuple[int, int]]
+
+
+MONTHS_RU = r"(январ[ья]|феврал[ья]|март[ае]?|апрел[ья]|ма[йя]|июн[ья]|июл[ья]|август[ае]?|сентябр[ья]|октябр[ья]|ноябр[ья]|декабр[ья])"
+
+
+def detect_answer_type(q: str) -> str:
+    ql = q.lower()
+    if "кто" in ql or "фамили" in ql or "бухгалтер" in ql or "директор" in ql or "должност" in ql or "как называется" in ql or "какой организацией" in ql:
+        return "string"
+    if "%" in ql or "процент" in ql or "в %" in ql:
+        return "percent"  # будет float
+    if "дата" in ql or re.search(r"\b(год|году|месяц)\b", ql):
+        return "int"  # чаще целое (годы/месяцы)
+    # по умолчанию число
+    return "float" if re.search(r"(значен|показател|тонн|частот|объём|объем)", ql) else "int"
+
+
+# Регэкспы
+RE_INT = re.compile(r"(?<![\d.,])\d{1,3}(?:[ \u00A0]\d{3})+|\d+")
+RE_FLOAT = re.compile(r"(?<![\d.,])\d{1,3}(?:[ \u00A0]\d{3})+[.,]\d+|\d+[.,]\d+")
+RE_PERCENT = re.compile(r"(?<![\d.,])\d{1,3}(?:[ \u00A0]\d{3})*[.,]?\d*\s?%|\d+[.,]?\d*\s?%")
+RE_DATE = re.compile(r"\b\d{1,2}\.\d{1,2}\.\d{4}\b|\b\d{1,2}\s+" + MONTHS_RU + r"\s+\d{4}\b", re.IGNORECASE)
+RE_NAME = re.compile(r"\b[А-ЯЁ][а-яё\-]+(?:\s+[А-ЯЁ][а-яё\-]+){1,2}\b")
+
+
+def _first_match(pat: re.Pattern, text: str):
+    m = pat.search(text)
+    if m:
+        return m.group(0), (m.start(), m.end())
+    return None, None
+
+
+def extract_answer_from_hits(question: str, hits: List[Dict], topk: int = 3) -> Answer:
+    atype = detect_answer_type(question)
+    text_pool = []
+    idx_map = []
+    for i, h in enumerate(hits[:topk]):
+        t = str(h.get("preview", "") or "")
+        if t:
+            text_pool.append(t)
+            idx_map.append(i)
+    big = "\n\n".join(text_pool)
+
+    # порядок поиска
+    if atype == "percent":
+        val, span = _first_match(RE_PERCENT, big)
+        if val:
+            return Answer(value=_fix_percent(val), atype="float", matched_hit_idx=_span2hit(span, text_pool, idx_map), matched_span=span)
+    if atype in ("float",):
+        val, span = _first_match(RE_FLOAT, big)
+        if val:
+            return Answer(value=_fix_number(val), atype="float", matched_hit_idx=_span2hit(span, text_pool, idx_map), matched_span=span)
+    if atype in ("int",):
+        val, span = _first_match(RE_INT, big)
+        if val:
+            return Answer(value=_fix_int(val), atype="int", matched_hit_idx=_span2hit(span, text_pool, idx_map), matched_span=span)
+    if atype == "string":
+        # простая эвристика: сначала имя/ФИО, иначе кавычки
+        val, span = _first_match(RE_NAME, big)
+        if not val:
+            m = re.search(r"«([^»]{2,80})»|\"([^\"\n]{2,80})\"", big)
+            if m:
+                val = m.group(1) or m.group(2)
+                span = (m.start(), m.end())
+        if val:
+            return Answer(value=val.strip(), atype="string", matched_hit_idx=_span2hit(span, text_pool, idx_map), matched_span=span)
+
+    return Answer(value="N/A", atype=atype, matched_hit_idx=None, matched_span=None)
+
+
+def _fix_number(s: str) -> float:
+    s = s.replace("\u00A0", " ").replace(" ", "").replace(",", ".")
+    return float(s)
+
+
+def _fix_int(s: str) -> int:
+    s = s.replace("\u00A0", " ").replace(" ", "")
+    s = s.split(",")[0].split(".")[0]
+    return int(s)
+
+
+def _fix_percent(s: str) -> float:
+    s = s.replace("%", "").strip()
+    s = s.replace("\u00A0", " ").replace(" ", "").replace(",", ".")
+    return float(s)
+
+
+def _span2hit(span, texts: List[str], idx_map: List[int]) -> Optional[int]:
+    if not span:
+        return None
+    start, _ = span
+    pos = 0
+    for t, idx in zip(texts, idx_map):
+        end = pos + len(t)
+        if pos <= start < end:
+            return idx
+        pos = end + 2  # "\n\n"
+    return None

--- a/src/validate/linkcheck.py
+++ b/src/validate/linkcheck.py
@@ -1,8 +1,9 @@
-from typing import Any
+from typing import Any, List, Dict
+import re
 
 
 def check_relevant_chunks(item: dict, allow_empty: bool = False) -> list[str]:
-    errs = []
+    errs: list[str] = []
     chunks = item.get("relevant_chunks", [])
     if not allow_empty and (not isinstance(chunks, list) or len(chunks) == 0):
         errs.append("relevant_chunks must be non-empty list")
@@ -17,3 +18,38 @@ def check_relevant_chunks(item: dict, allow_empty: bool = False) -> list[str]:
         if not isinstance(pn, int) or pn < 1:
             errs.append("page_number must be integer >= 1")
     return errs
+
+
+def norm_space(s: str) -> str:
+    return re.sub(r"\s+", " ", (s or "").replace("\u00A0", " ")).strip().lower()
+
+
+def number_variants(x) -> List[str]:
+    s = str(x)
+    if isinstance(x, float) and s.endswith(".0"):
+        s = s[:-2]
+    raw = s.replace("\u00A0", " ").replace(" ", "")
+    out = {raw, raw.replace(".", ","), raw.replace(",", ".")}
+    if raw.isdigit() and len(raw) > 4:
+        with_spaces = " ".join([raw[::-1][i:i+3] for i in range(0, len(raw), 3)])[::-1]
+        out.update({with_spaces, with_spaces.replace(" ", "\u00A0")})
+    return list(out)
+
+
+def linkcheck(answer_value, atype: str, hits: List[Dict], topk: int = 3) -> int:
+    """Возвращает индекс хита, подтверждающего ответ, либо -1."""
+    pool = hits[:topk]
+    if atype in ("int", "float"):
+        variants = number_variants(answer_value)
+        for i, h in enumerate(pool):
+            text = (h.get("preview") or "")
+            for v in variants:
+                if v and v in text:
+                    return i
+        return -1
+    else:
+        tgt = norm_space(str(answer_value))
+        for i, h in enumerate(pool):
+            if tgt and tgt in norm_space(h.get("preview") or ""):
+                return i
+        return -1


### PR DESCRIPTION
## Summary
- add regex-based answer extractor and basic answer data class
- implement link checking utilities for numeric and string answers
- add public-answer CLI to search documents and build submissions

## Testing
- `python -m src.cli.answer_public --help`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a62461f0b48324a480ac526ebb95f7