### PR TITLE
Add hyphenation cleanup for previews

### DIFF
--- a/src/reader/extract.py
+++ b/src/reader/extract.py
@@ -25,6 +25,15 @@ STOPWORDS_TITLE = {"главный", "финансовый", "республик
 def _norm(s: str) -> str:
     return (s or "").replace(NBSP, " ")
 
+
+def cleanup_hyphenation(text: str) -> str:
+    """Remove hyphenation "-\n" and collapse newlines to spaces."""
+    if not text:
+        return ""
+    text = text.replace("-\n", "")
+    text = re.sub(r"\n+", " ", text)
+    return text
+
 def _first_match(pat: re.Pattern, text: str):
     m = pat.search(text)
     if m:
@@ -325,7 +334,7 @@ def extract_answer_from_hits(question: str, hits: List[Dict], topk: int = 5) -> 
     atype = detect_answer_type(question)
     text_pool, idx_map = [], []
     for i, h in enumerate(hits[:max(1, topk)]):
-        t = str(h.get("preview", "") or "")
+        t = cleanup_hyphenation(str(h.get("preview", "") or ""))
         if t:
             text_pool.append(t)
             idx_map.append(i)

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,0 +1,14 @@
+from src.reader.extract import cleanup_hyphenation, extract_answer_from_hits
+
+
+def test_cleanup_hyphenation_basic():
+    text = "Ива-\nнов\nИван"
+    assert cleanup_hyphenation(text) == "Иванов Иван"
+
+
+def test_extract_answer_with_hyphenated_fio():
+    question = "Кто подписал отчёт?"
+    hits = [{"preview": "Отчёт подписал Ива-\nнов Иван Иванович."}]
+    ans = extract_answer_from_hits(question, hits, topk=1)
+    assert ans.value == "Иванов Иван Иванович"
+


### PR DESCRIPTION
## Summary
- add `cleanup_hyphenation` to normalize OCR line breaks and hyphenation
- integrate cleanup into `extract_answer_from_hits`
- cover hyphenated FIO scenario with unit tests

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a71ccbd0048324b24d400e0804cd4a